### PR TITLE
feat: 新增outlook邮箱提供商

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ GPT-Register-Tool 采用 **WPF 桌面端 + Python 业务核心**，提供邮箱 
 
 ### 适用场景
 
-- 从邮箱池、ReMail 或 CFWorker 执行批量邮箱注册。
-- 统一轮询 Microsoft、Gmail、iCloud 接码链接、ReMail、CFWorker 等邮箱的 OTP。
+- 从邮箱池、ReMail、MailNest 或 CFWorker 执行批量邮箱注册。
+- 统一轮询 Microsoft、Gmail、iCloud 接码链接、ReMail、MailNest、CFWorker 等邮箱的 OTP。
 - 管理本地账号、Session、额度状态和支付链接。
 - 按阶段选择代理出口并提取 PayPal 或其他本地支付方式链接。
 - 将账号数据导出为 Codex、CPA、SUB2API 等目标格式。
@@ -53,7 +53,7 @@ GPT-Register-Tool 采用 **WPF 桌面端 + Python 业务核心**，提供邮箱 
 | 桌面端 | WPF、.NET 10、C#、Generic Host、CommunityToolkit.Mvvm、WPF-UI |
 | 业务核心 | Python 3、curl_cffi、requests、httpx、PyNaCl（Ed25519） |
 | 数据存储 | JSON、JSONL、SQLite |
-| 邮箱协议 | ReMail API、CFWorker、iCloud 接码链接、Microsoft Graph/OAuth、IMAP、Gmail IMAP |
+| 邮箱协议 | ReMail API、MailNest API、CFWorker、iCloud 接码链接、Microsoft Graph/OAuth、IMAP、Gmail IMAP |
 | 支付协议 | Stripe Checkout、PayPal、GoPay、GCash、GrabPay、UPI、iDEAL、PIX、Kakao Pay、BLIK、TWINT、直卡 Checkout、MoMo |
 | 浏览器辅助 | Playwright、Camoufox、CloakBrowser、RoxyBrowser、AdsPower |
 
@@ -199,6 +199,7 @@ $env:REMAIL_API_KEY = "rk-your-key"
 统一 mailbox seam 支持：
 
 - ReMail。
+- MailNest：支持 `email----password----client_id----refresh_token` Graph 令牌号直接导入，也支持通过 MailNest API 购买临时/独占邮箱或读取已上传私有邮箱。
 - Smailr（`smailr.com`、`loc.cc`、`mail.nodeloc.cc`、`nodeloc.cc`），支持受等级限制时复用已有未绑定邮箱、详情正文补取和 10 秒服务端时钟偏差。
 - CFWorker 域名邮箱。
 - Microsoft Graph/OAuth。
@@ -320,7 +321,7 @@ sms_tool/gcash_provider.py / gcash_transport.py
 
 sms_tool/mailbox.py
   邮箱统一路由
-  -> ReMail / CFWorker / Graph / IMAP / Gmail
+  -> ReMail / MailNest / CFWorker / Graph / IMAP / Gmail
 
 sms_tool/payment_link_manager.py
   协议支付管理器
@@ -356,6 +357,7 @@ services/
 | `sms_tool/account_recovery.py` | 本地额度刷新、401 分层恢复、候选 AT 验证与停用账号持久化 |
 | `sms_tool/mailbox.py` | 邮箱 provider 路由与统一 OTP 轮询 |
 | `sms_tool/mailbox_remail.py` | ReMail 下单、收件、详情读取和 OTP 提取 |
+| `sms_tool/mailbox_mailnest.py` | MailNest API 下单、用户邮箱收件、Graph 令牌格式支持 |
 | `sms_tool/mailbox_cfworker.py` | CFWorker 邮箱创建与收件 |
 | `sms_tool/mailbox_graph.py` | Microsoft OAuth 与 Graph 边界 |
 | `sms_tool/mailbox_gmail.py` | Gmail IMAP/SMTP 与 OAuth |
@@ -420,6 +422,38 @@ services/
     "remail_otp_resend_after_seconds": 30
   }
 }
+```
+
+### MailNest
+
+官网：[https://mailnest.top](https://mailnest.top)
+
+MailNest 有两种接入方式：
+
+- Graph 令牌号直接导入：在邮箱文件中写入 `mailnest://email----password----client_id----refresh_token`，会走 Microsoft Graph OAuth 刷新和 Graph 收信。可以直接在 <https://mailnest.top/buy-account> 购买。
+- MailNest API 收信：配置 API Key 后，使用 `--buy-mailnest-mailbox` 购买临时/独占邮箱，或用 `--mailnest-mode user_mailbox` 读取已上传到 MailNest 的私有 Outlook 邮箱。API Key 获取页面 <https://mailnest.top/account>。
+
+```json
+{
+  "email_registration": {
+    "mailnest": {
+      "enabled": true,
+      "base_url": "https://mailnest.top",
+      "api_key": "",
+      "project_code": "chatgpt001",
+      "mode": "temporary",
+      "email": "",
+      "timeout": 30
+    },
+    "mailnest_otp_issued_after_grace_seconds": 10
+  }
+}
+```
+
+`api_key` 也可以用环境变量提供：
+
+```powershell
+$env:MAILNEST_API_KEY = "YOUR_API_KEY"
 ```
 
 ### 注册与收件代理
@@ -533,6 +567,28 @@ python chatgpt_phone_reg.py --buy-remail-mailbox --remail-service-mode purchase 
 ```
 
 该模式跳过 Codex OAuth RT 和手机验证，只在 Session 已落盘且 AT 探活返回 HTTP 200 后计为成功。
+
+### MailNest API 邮箱注册
+
+```powershell
+python chatgpt_phone_reg.py --buy-mailnest-mailbox --mailnest-mode temporary --mailnest-project-code chatgpt001 --count 1 --workers 1
+```
+
+`--mailnest-mode exclusive` 会购买 MailNest 独占邮箱；`--mailnest-mode user_mailbox` 会从 MailNest 已上传的私有 Outlook 邮箱列表取邮箱并通过 `/api/v1/email/user-mailbox/receive` 收信，不会购买新邮箱。
+
+### MailNest Graph 令牌号注册
+
+邮箱文件每行使用：
+
+```text
+mailnest://email----password----client_id----refresh_token
+```
+
+然后执行：
+
+```powershell
+python chatgpt_phone_reg.py --mailbox-file mailnest_graph.txt --count 1 --workers 1
+```
 
 ### CFWorker 邮箱注册
 

--- a/config.example.json
+++ b/config.example.json
@@ -149,6 +149,15 @@
       "reuse_existing_on_level_error": true,
       "timeout": 30
     },
+    "mailnest": {
+      "enabled": false,
+      "base_url": "https://mailnest.top",
+      "api_key": "",
+      "project_code": "chatgpt001",
+      "mode": "temporary",
+      "email": "",
+      "timeout": 30
+    },
     "otp_poll_interval": 2,
     "sentinel_version": "20260219f9f6",
     "sentinel_backend": "node_runner",

--- a/sms_tool/cli.py
+++ b/sms_tool/cli.py
@@ -234,6 +234,9 @@ def build_parser():
     parser.add_argument("--cfworker-domain", default=None, help="CF Worker mailbox domain, default cfworker_domain in config.json")
     parser.add_argument("--buy-smailr-mailbox", action="store_true", help="Use Smailr disposable mailboxes before registration")
     parser.add_argument("--smailr-domain", default=None, help="Smailr mailbox domain, default smailr.default_domain in config.json")
+    parser.add_argument("--buy-mailnest-mailbox", action="store_true", help="Use MailNest API mailboxes before registration")
+    parser.add_argument("--mailnest-mode", choices=["temporary", "exclusive", "user_mailbox"], default=None, help="MailNest mailbox mode; user_mailbox uses uploaded Outlook Graph accounts")
+    parser.add_argument("--mailnest-project-code", default=None, help="MailNest temporary-mailbox project code, default mailnest.project_code")
     parser.add_argument("--remail-service-mode", choices=["code", "purchase"], default=None, help="ReMail service mode override")
     parser.add_argument("--remail-supply", choices=["private_first", "public_only"], default=None, help="ReMail inventory policy")
     parser.add_argument("--remail-email-suffix", default=None, help="ReMail mailbox domain suffix")
@@ -610,6 +613,7 @@ def main():
         or args.remail_service_mode
         or args.buy_cfworker_mailbox
         or args.buy_smailr_mailbox
+        or args.buy_mailnest_mailbox
     )
     if not mailboxes and explicit_mailbox_source:
         print("[Error] no mailbox account was found from the requested source; check the selected mailbox row or mailbox file format")
@@ -625,6 +629,10 @@ def main():
         effective_count = len(mailboxes)
         if effective_count != requested_count:
             print(f"[!] Requested {requested_count} mailbox(es), ReMail returned {effective_count}; registering returned mailboxes only.")
+    elif getattr(args, "buy_mailnest_mailbox", False):
+        effective_count = len(mailboxes)
+        if effective_count != requested_count:
+            print(f"[!] Requested {requested_count} mailbox(es), MailNest returned {effective_count}; registering returned mailboxes only.")
     elif getattr(args, "buy_cfworker_mailbox", False):
         effective_count = len(mailboxes)
         if effective_count != requested_count:

--- a/sms_tool/desktop_read.py
+++ b/sms_tool/desktop_read.py
@@ -298,7 +298,7 @@ def _pool_line_payload(account, raw_line: str) -> dict[str, Any]:
     # chatai/chongzhi and Gmail-OAuth lines store the OAuth client id in the
     # generic token slot; surface it explicitly so callers need no format
     # knowledge.
-    client_id = account.token if provider in {"chatai", "chongzhi"} or (
+    client_id = account.token if provider in {"chatai", "chongzhi", "mailnest_graph"} or (
         provider == "gmail" and account.auth_mode == "oauth_refresh"
     ) else ""
     return {
@@ -482,6 +482,19 @@ def _mailbox_line(mailbox: dict[str, Any]) -> str:
         purchase = str(mailbox.get("purchase_id") or "").strip()
         # Keep the canonical ReMail line format used by mailbox_parsers.
         return "remail://" + "---".join(filter(None, (email, token, order, purchase)))
+    if provider == "mailnest":
+        mode = str(mailbox.get("auth_mode") or "temporary").strip().replace("-", "_")
+        token = str(mailbox.get("token") or mailbox.get("order_no") or mailbox.get("purchase_id") or "").strip()
+        return "mailnest://" + "---".join(filter(None, (email, mode, token)))
+    if provider == "mailnest_graph":
+        password = str(mailbox.get("password") or "").strip()
+        refresh = str(mailbox.get("refresh_token") or "").strip()
+        access = str(mailbox.get("access_token") or "").strip()
+        client = str(mailbox.get("client_id") or mailbox.get("clientId") or mailbox.get("token") or "").strip()
+        if client and refresh:
+            line = f"mailnest://{email}----{password}----{client}----{refresh}"
+            return f"{line}----{access}" if access else line
+        return ""
     if provider == "gmail":
         client = str(mailbox.get("client_id") or mailbox.get("token") or "").strip()
         secret = str(mailbox.get("client_secret") or "").strip()

--- a/sms_tool/mail_otp.py
+++ b/sms_tool/mail_otp.py
@@ -229,4 +229,4 @@ def _requires_openai_sender_filter(mailbox):
     provider = str(getattr(mailbox, "provider", "") or "").strip().lower()
     email = str(getattr(mailbox, "email", "") or "").strip().lower()
     domain = email.rsplit("@", 1)[1] if "@" in email else ""
-    return provider in {"gmail", "graph", "chatai", "outlook"} or domain in GMAIL_DOMAINS or domain in OUTLOOK_DOMAINS
+    return provider in {"gmail", "graph", "chatai", "mailnest_graph", "outlook"} or domain in GMAIL_DOMAINS or domain in OUTLOOK_DOMAINS

--- a/sms_tool/mailbox.py
+++ b/sms_tool/mailbox.py
@@ -36,6 +36,7 @@ from .mailbox_graph import MailboxTokenExpiredError
 from . import mailbox_chongzhi
 from . import mailbox_icloud_url
 from . import mailbox_smailr
+from . import mailbox_mailnest
 from . import mailbox_strategies
 
 # MailboxAccount and parsers moved to mailbox_types/mailbox_parsers.
@@ -97,6 +98,21 @@ def _register_mailbox_strategies():
             excluded_otps=excluded_otps,
             poll_interval=None,
         ),
+    )
+
+    # MailNest API mailboxes. MailNest Graph-token accounts are parsed as
+    # provider=mailnest_graph and intentionally fall through to Graph fallback.
+    mailbox_strategies.register_message_fetcher(
+        "mailnest",
+        lambda mb, cfg: str(getattr(mb, "provider", "") or "") == mailbox_mailnest.API_PROVIDER,
+        lambda mb, *, limit, proxy, include_body, email_cfg, **kw: mailbox_mailnest._fetch_mailnest_messages(
+            mb, limit=limit, proxy=proxy, include_body=include_body, email_cfg=email_cfg,
+        ),
+    )
+    mailbox_strategies.register_otp_poller(
+        "mailnest",
+        lambda mb, cfg: str(getattr(mb, "provider", "") or "") == mailbox_mailnest.API_PROVIDER,
+        lambda mb, **kw: mailbox_mailnest._poll_mailnest_otp(mb, **kw),
     )
 
     # smailr
@@ -271,6 +287,7 @@ def _provider_otp_issued_after(mailbox, issued_after_unix, runtime_config: Confi
     defaults = {
         "remail": 90,
         "smailr": 10,
+        "mailnest": 10,
         "cfworker": 10,
         mailbox_icloud_url.PROVIDER: 90,
     }
@@ -320,6 +337,10 @@ def _create_smailr_mailboxes(args=None):
     count = max(1, int(getattr(args, "count", 1) or 1))
     domain = getattr(args, "smailr_domain", None) or None
     return mailbox_smailr.create_smailr_mailboxes(count, domain=domain)
+
+
+def _create_mailnest_mailboxes(args=None):
+    return mailbox_mailnest._create_mailnest_mailboxes(args)
 
 
 def _default_nb_register_token_file():
@@ -435,6 +456,12 @@ def _mailbox_from_config(args=None):
     email = (getattr(args, "email", None) or _email_cfg().get("email") or "").strip().lower()
     if not email and remail_token:
         email = str(remail_cfg.get("delivery_email") or "").strip().lower()
+    mailnest_cfg = mailbox_mailnest._mailnest_cfg(_email_cfg())
+    mailnest_email = str(mailnest_cfg.get("email") or "").strip().lower()
+    use_mailnest_config = False
+    if not email and mailnest_email:
+        email = mailnest_email
+        use_mailnest_config = True
     if not email:
         return None
     if remail_token:
@@ -444,6 +471,13 @@ def _mailbox_from_config(args=None):
             provider="remail",
             token=remail_token,
             order_no=str(remail_cfg.get("order_no") or "").strip(),
+        )
+    if use_mailnest_config:
+        return MailboxAccount(
+            email=mailnest_email,
+            source="mailnest_config",
+            provider=mailbox_mailnest.API_PROVIDER,
+            auth_mode=mailbox_mailnest._mailnest_mode(args, _email_cfg()),
         )
     return MailboxAccount(
         email=email,
@@ -472,6 +506,8 @@ def _load_mailbox_pool(args=None):
         pool = _create_cfworker_mailboxes(args)
     elif getattr(args, "buy_smailr_mailbox", False):
         pool = _create_smailr_mailboxes(args)
+    elif getattr(args, "buy_mailnest_mailbox", False):
+        pool = _create_mailnest_mailboxes(args)
     elif getattr(args, "chatai_mailbox_file", None):
         pool = _parse_chatai_mailbox_file(args.chatai_mailbox_file)
     elif getattr(args, "mailbox_file", None):
@@ -582,6 +618,10 @@ def mailbox_has_inbox_credentials(mailbox):
         return bool(getattr(mailbox, "token", "") and getattr(mailbox, "email", ""))
     if provider == "smailr":
         return bool(getattr(mailbox, "token", "") and getattr(mailbox, "email", ""))
+    if provider == mailbox_mailnest.API_PROVIDER:
+        return bool(getattr(mailbox, "email", ""))
+    if provider == mailbox_mailnest.GRAPH_PROVIDER:
+        return bool(getattr(mailbox, "refresh_token", "") and getattr(mailbox, "email", ""))
     if provider == mailbox_icloud_url.PROVIDER:
         return bool(getattr(mailbox, "token", "") and getattr(mailbox, "email", ""))
     if mailbox_gmail.is_gmail_mailbox(mailbox):

--- a/sms_tool/mailbox_mailnest.py
+++ b/sms_tool/mailbox_mailnest.py
@@ -1,0 +1,363 @@
+"""MailNest mailbox provider.
+
+MailNest supports two mailbox shapes used by this project:
+
+* Outlook Graph token accounts delivered as
+  ``email----password----client_id----refresh_token``.  Those accounts use the
+  existing Microsoft Graph path after parsing.
+* MailNest API mailboxes, either bought from MailNest or uploaded as
+  user-mailboxes, fetched through MailNest's REST API.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Mapping
+
+from curl_cffi import requests as curl_requests
+
+from .config import CFG
+from .mail_otp import _candidate_is_newer, _email_otp_candidate
+from .mailbox_types import MailboxAccount
+
+
+DEFAULT_BASE_URL = "https://mailnest.top"
+DEFAULT_PROJECT_CODE = "chatgpt001"
+API_PROVIDER = "mailnest"
+GRAPH_PROVIDER = "mailnest_graph"
+TEMPORARY_MODE = "temporary"
+EXCLUSIVE_MODE = "exclusive"
+USER_MAILBOX_MODE = "user_mailbox"
+VALID_API_MODES = {TEMPORARY_MODE, EXCLUSIVE_MODE, USER_MAILBOX_MODE}
+TRANSIENT_RECEIVE_CODES = {"D0005"}
+
+
+class MailNestApiError(RuntimeError):
+    def __init__(self, status_code: int, body: Any) -> None:
+        self.status_code = int(status_code or 0)
+        self.body = body
+        super().__init__(f"MailNest API {self.status_code}: {_safe_error(body)}")
+
+
+def _email_cfg() -> Mapping[str, Any]:
+    value = CFG.get("email_registration", {})
+    return value if isinstance(value, Mapping) else {}
+
+
+def _mailnest_cfg(email_cfg: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
+    cfg = email_cfg if isinstance(email_cfg, Mapping) else _email_cfg()
+    nested = cfg.get("mailnest") if isinstance(cfg, Mapping) else {}
+    return nested if isinstance(nested, Mapping) else {}
+
+
+def _mailnest_api_key(email_cfg: Mapping[str, Any] | None = None) -> str:
+    return str(os.environ.get("MAILNEST_API_KEY") or _mailnest_cfg(email_cfg).get("api_key") or "").strip()
+
+
+def _mailnest_base_url(email_cfg: Mapping[str, Any] | None = None) -> str:
+    return str(_mailnest_cfg(email_cfg).get("base_url") or DEFAULT_BASE_URL).strip().rstrip("/")
+
+
+def _mailnest_timeout(email_cfg: Mapping[str, Any] | None = None) -> int:
+    try:
+        return max(1, int(_mailnest_cfg(email_cfg).get("timeout") or 30))
+    except (TypeError, ValueError):
+        return 30
+
+
+def _mailnest_enabled(email_cfg: Mapping[str, Any] | None = None) -> bool:
+    cfg = _mailnest_cfg(email_cfg)
+    enabled = cfg.get("enabled")
+    if enabled is not None and str(enabled).strip().lower() in {"0", "false", "no", "off"}:
+        return False
+    return bool(_mailnest_api_key(email_cfg))
+
+
+def _mailnest_mode(args: Any = None, email_cfg: Mapping[str, Any] | None = None) -> str:
+    raw = (
+        getattr(args, "mailnest_mode", None)
+        or _mailnest_cfg(email_cfg).get("mode")
+        or TEMPORARY_MODE
+    )
+    mode = str(raw or "").strip().lower().replace("-", "_")
+    if mode in {"user", "private", "private_mailbox"}:
+        mode = USER_MAILBOX_MODE
+    if mode not in VALID_API_MODES:
+        raise RuntimeError("mailnest.mode must be temporary, exclusive, or user_mailbox")
+    return mode
+
+
+def _mailnest_project_code(args: Any = None, email_cfg: Mapping[str, Any] | None = None) -> str:
+    value = (
+        getattr(args, "mailnest_project_code", None)
+        or _mailnest_cfg(email_cfg).get("project_code")
+        or DEFAULT_PROJECT_CODE
+    )
+    return str(value or "").strip()
+
+
+def _create_mailnest_mailboxes(args: Any = None) -> list[MailboxAccount]:
+    args = args or object()
+    cfg = _email_cfg()
+    mode = _mailnest_mode(args, cfg)
+    count = max(1, min(int(getattr(args, "count", 1) or 1), 100))
+    if mode == USER_MAILBOX_MODE:
+        return _list_user_mailboxes(count=count, email_cfg=cfg)
+
+    payload: dict[str, Any] = {"count": count}
+    if mode == TEMPORARY_MODE:
+        project_code = _mailnest_project_code(args, cfg)
+        if not project_code:
+            raise RuntimeError("mailnest.project_code is required for temporary mailbox purchases")
+        payload["project_code"] = project_code
+        path = "/api/v1/email/temporary/buy"
+    else:
+        path = "/api/v1/email/exclusive/buy"
+    body = _mailnest_request("POST", path, json_body=payload, email_cfg=cfg)
+    items = _as_items(body.get("data") if isinstance(body, dict) else body)
+    accounts = [_account_from_api_item(item, source=f"mailnest_{mode}", mode=mode) for item in items]
+    accounts = [account for account in accounts if account is not None]
+    if not accounts:
+        raise RuntimeError("MailNest mailbox purchase returned no usable mailboxes")
+    return accounts[:count]
+
+
+def _list_user_mailboxes(count: int, email_cfg: Mapping[str, Any] | None = None) -> list[MailboxAccount]:
+    body = _mailnest_request(
+        "GET",
+        f"/api/v1/email/user-mailbox?page=1&page_size={max(1, min(count, 100))}",
+        email_cfg=email_cfg,
+    )
+    data = body.get("data") if isinstance(body, dict) else {}
+    items = data.get("items") if isinstance(data, dict) else data
+    accounts = [
+        _account_from_api_item(item, source="mailnest_user_mailbox", mode=USER_MAILBOX_MODE)
+        for item in _as_items(items)
+    ]
+    return [account for account in accounts if account is not None][:count]
+
+
+def _fetch_mailnest_messages(
+    mailbox: MailboxAccount,
+    *,
+    limit: int = 25,
+    proxy: str | None = None,
+    include_body: bool = False,
+    email_cfg: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> list[dict[str, Any]]:
+    email = str(getattr(mailbox, "email", "") or "").strip().lower()
+    if not email:
+        return []
+    mode = _normalize_api_mode(getattr(mailbox, "auth_mode", "") or _mailnest_mode(email_cfg=email_cfg))
+    path = "/api/v1/email/user-mailbox/receive" if mode == USER_MAILBOX_MODE else "/api/v1/email/receive"
+    try:
+        body = _mailnest_request(
+            "POST",
+            path,
+            json_body={"email": email},
+            email_cfg=email_cfg,
+            proxy=proxy,
+            transient_codes=TRANSIENT_RECEIVE_CODES,
+        )
+    except MailNestApiError as exc:
+        if _mailnest_error_code(exc.body) in TRANSIENT_RECEIVE_CODES:
+            return []
+        raise
+    data = body.get("data") if isinstance(body, dict) else body
+    messages = [_normalize_mailnest_message(item, email=email) for item in _as_items(data)]
+    return messages[: max(1, min(int(limit or 25), 100))]
+
+
+def _latest_mailnest_otp_candidate(
+    mailbox: MailboxAccount,
+    *,
+    keyword: str = "",
+    issued_after_unix: int = 0,
+    proxy: str | None = None,
+    email_cfg: Mapping[str, Any] | None = None,
+    excluded_otps: Any = None,
+) -> dict[str, Any] | None:
+    excluded = {str(value or "").strip() for value in (excluded_otps or ())}
+    latest = None
+    for msg in _fetch_mailnest_messages(mailbox, proxy=proxy, email_cfg=email_cfg):
+        candidate = _email_otp_candidate(mailbox, msg, keyword=keyword, issued_after_unix=issued_after_unix)
+        if not candidate or str(candidate.get("otp") or "").strip() in excluded:
+            continue
+        if _candidate_is_newer(candidate, latest):
+            latest = candidate
+    return latest
+
+
+def _poll_mailnest_otp(
+    mailbox: MailboxAccount,
+    *,
+    subject_keyword: str = "",
+    timeout: int = 300,
+    issued_after_unix: int = 0,
+    proxy: str | None = None,
+    excluded_otps: Any = None,
+    email_cfg: Mapping[str, Any] | None = None,
+    **_: Any,
+) -> str | None:
+    from .mailbox import _email_otp_settle_seconds, _otp_poll_interval
+    from .mailbox_poll import _poll_otp_with_settle
+
+    keyword = str(subject_keyword or "").lower()
+
+    def fetch_candidate() -> dict[str, Any] | None:
+        return _latest_mailnest_otp_candidate(
+            mailbox,
+            keyword=keyword,
+            issued_after_unix=issued_after_unix,
+            proxy=proxy,
+            email_cfg=email_cfg,
+            excluded_otps=excluded_otps,
+        )
+
+    return _poll_otp_with_settle(
+        fetch_candidate,
+        timeout=timeout,
+        interval=_otp_poll_interval(),
+        settle_seconds=_email_otp_settle_seconds(),
+        excluded_otps=excluded_otps,
+        log_prefix="mailnest poll",
+        is_newer=_candidate_is_newer,
+    )
+
+
+def _mailnest_request(
+    method: str,
+    path: str,
+    *,
+    json_body: Mapping[str, Any] | None = None,
+    email_cfg: Mapping[str, Any] | None = None,
+    proxy: str | None = None,
+    transient_codes: set[str] | None = None,
+) -> dict[str, Any]:
+    base_url = _mailnest_base_url(email_cfg)
+    api_key = _mailnest_api_key(email_cfg)
+    if not base_url:
+        raise RuntimeError("mailnest.base_url is required")
+    if not api_key:
+        raise RuntimeError("mailnest.api_key is required")
+    url = base_url + (path if path.startswith("/") else "/" + path)
+    headers = {
+        "Accept": "application/json",
+        "Authorization": "Bearer " + api_key,
+    }
+    proxies = {"http": proxy, "https": proxy} if proxy else None
+    timeout = _mailnest_timeout(email_cfg)
+    method = method.upper()
+    if method == "POST":
+        response = curl_requests.post(
+            url,
+            headers={**headers, "Content-Type": "application/json"},
+            json=dict(json_body or {}),
+            proxies=proxies,
+            impersonate="chrome124",
+            timeout=timeout,
+        )
+    elif method == "GET":
+        response = curl_requests.get(
+            url,
+            headers=headers,
+            proxies=proxies,
+            impersonate="chrome124",
+            timeout=timeout,
+        )
+    else:
+        raise ValueError(f"unsupported MailNest method: {method}")
+    try:
+        body = response.json()
+    except Exception:
+        body = {"raw": str(getattr(response, "text", ""))[:500]}
+    if response.status_code != 200:
+        raise MailNestApiError(response.status_code, body)
+    code = _mailnest_error_code(body)
+    if code and code != "00000":
+        if transient_codes and code in transient_codes:
+            return body if isinstance(body, dict) else {"data": None}
+        raise MailNestApiError(response.status_code, body)
+    return body if isinstance(body, dict) else {"data": body}
+
+
+def _account_from_api_item(item: Any, *, source: str, mode: str) -> MailboxAccount | None:
+    if not isinstance(item, Mapping):
+        return None
+    email = str(item.get("email") or "").strip().lower()
+    if not email or "@" not in email:
+        return None
+    mailbox_id = str(item.get("id") or item.get("order_id") or "").strip()
+    return MailboxAccount(
+        email=email,
+        password=str(item.get("password") or ""),
+        refresh_token=str(item.get("refresh_token") or ""),
+        source=json.dumps(dict(item), ensure_ascii=False, separators=(",", ":")),
+        provider=API_PROVIDER,
+        token=mailbox_id,
+        order_no=mailbox_id,
+        purchase_id=mailbox_id,
+        auth_mode=_normalize_api_mode(mode),
+        project_name=str(item.get("project_name") or item.get("project_code") or ""),
+        price=str(item.get("price") or ""),
+    )
+
+
+def _normalize_mailnest_message(msg: Any, *, email: str) -> dict[str, Any]:
+    if not isinstance(msg, Mapping):
+        msg = {"body": str(msg or "")}
+    code = str(msg.get("code_match") or "").strip()
+    body = str(msg.get("body") or msg.get("body_preview") or msg.get("bodyPreview") or "")
+    if code and code not in body:
+        body = f"{code}\n{body}"
+    body_preview = str(msg.get("body_preview") or msg.get("bodyPreview") or body)[:500]
+    if code and code not in body_preview:
+        body_preview = f"{code} {body_preview}".strip()[:500]
+    from_email = str(msg.get("from_email") or msg.get("from_domain") or "")
+    return {
+        "id": str(msg.get("id") or msg.get("message_id") or ""),
+        "receivedDateTime": str(msg.get("received_at") or msg.get("receivedDateTime") or ""),
+        "from": {"emailAddress": {"address": from_email}},
+        "sender": {"emailAddress": {"address": from_email}},
+        "subject": str(msg.get("subject") or ""),
+        "bodyPreview": body_preview,
+        "body": {"content": body},
+        "toRecipients": [{"emailAddress": {"address": str(msg.get("to_email") or email)}}],
+    }
+
+
+def _normalize_api_mode(value: Any) -> str:
+    mode = str(value or TEMPORARY_MODE).strip().lower().replace("-", "_")
+    if mode in {"user", "private", "private_mailbox"}:
+        return USER_MAILBOX_MODE
+    if mode in VALID_API_MODES:
+        return mode
+    return TEMPORARY_MODE
+
+
+def _mailnest_error_code(body: Any) -> str:
+    return str(body.get("code") or "").strip() if isinstance(body, Mapping) else ""
+
+
+def _as_items(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    if isinstance(value, Mapping):
+        items = value.get("items")
+        if isinstance(items, list):
+            return items
+        data = value.get("data")
+        if isinstance(data, list):
+            return data
+    return []
+
+
+def _safe_error(body: Any) -> str:
+    if isinstance(body, str):
+        return body[:500]
+    try:
+        return json.dumps(body, ensure_ascii=False, default=str)[:500]
+    except Exception:
+        return str(body)[:500]

--- a/sms_tool/mailbox_parsers.py
+++ b/sms_tool/mailbox_parsers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from .mailbox_types import MailboxAccount
 from . import mailbox_icloud_url
+from . import mailbox_mailnest
 
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 MS_CLIENT_ID_RE = re.compile(
@@ -63,6 +64,10 @@ def _is_gmail_line(line):
 
 def _is_remail_line(line):
     return line.lower().startswith("remail://")
+
+
+def _is_mailnest_line(line):
+    return line.lower().startswith("mailnest://")
 
 
 def _is_smailr_line(line):
@@ -138,6 +143,52 @@ def _parse_remail_line(line, source_path, line_no):
         token=service_token,
         order_no=order_no,
         purchase_id=purchase_id,
+    )
+
+
+def _parse_mailnest_line(line, source_path, line_no):
+    payload = line.split("://", 1)[1].strip() if "://" in line else line.strip()
+    if "----" in payload:
+        parts = [part.strip() for part in payload.split("----", 4)]
+        email = _normalize_mailbox_email(parts[0] if parts else "")
+        password = parts[1] if len(parts) >= 2 else ""
+        client_id = parts[2] if len(parts) >= 3 else ""
+        refresh_token = parts[3] if len(parts) >= 4 else ""
+        access_token = parts[4] if len(parts) >= 5 else ""
+        if not email or not client_id or not refresh_token:
+            print(f"[!] Skip malformed MailNest Graph mailbox line {source_path}:{line_no}")
+            return None
+        return MailboxAccount(
+            email=email.lower(),
+            password=password,
+            refresh_token=refresh_token,
+            access_token=access_token,
+            source=str(source_path),
+            provider=mailbox_mailnest.GRAPH_PROVIDER,
+            token=client_id,
+            auth_mode="oauth_refresh",
+        )
+
+    parts = [part.strip() for part in payload.split("---")]
+    email = _normalize_mailbox_email(parts[0] if parts else "")
+    mode = parts[1].replace("-", "_").lower() if len(parts) >= 2 and parts[1] else mailbox_mailnest.TEMPORARY_MODE
+    if mode in {"user", "private", "private_mailbox"}:
+        mode = mailbox_mailnest.USER_MAILBOX_MODE
+    mailbox_id = parts[2] if len(parts) >= 3 else ""
+    if mode not in mailbox_mailnest.VALID_API_MODES:
+        print(f"[!] Skip malformed MailNest mailbox mode {source_path}:{line_no}")
+        return None
+    if not email:
+        print(f"[!] Skip malformed MailNest email {source_path}:{line_no}")
+        return None
+    return MailboxAccount(
+        email=email.lower(),
+        source=str(source_path),
+        provider=mailbox_mailnest.API_PROVIDER,
+        token=mailbox_id,
+        order_no=mailbox_id,
+        purchase_id=mailbox_id,
+        auth_mode=mode,
     )
 
 
@@ -244,6 +295,8 @@ def parse_mailbox_pool_line(line, source_path="", line_no=0):
         return None
     if _is_remail_line(line):
         return _parse_remail_line(line, source_path, line_no)
+    if _is_mailnest_line(line):
+        return _parse_mailnest_line(line, source_path, line_no)
     if _is_smailr_line(line):
         return _parse_smailr_line(line, source_path, line_no)
     if _is_icloud_url_line(line):
@@ -298,6 +351,11 @@ def _parse_mailbox_token_file(path):
             continue
         if _is_remail_line(line):
             account = _parse_remail_line(line, token_path, line_no)
+            if account:
+                records.append(account)
+            continue
+        if _is_mailnest_line(line):
+            account = _parse_mailnest_line(line, token_path, line_no)
             if account:
                 records.append(account)
             continue

--- a/sms_tool/mailbox_strategies.py
+++ b/sms_tool/mailbox_strategies.py
@@ -178,7 +178,7 @@ def resolve_otp_poller(
 def _graph_matcher(mailbox: Any, cfg: dict) -> bool:
     """Default matcher — only match if no provider-specific strategy applies."""
     provider = str(getattr(mailbox, "provider", "") or "").strip().lower()
-    if provider in {"cfworker", "remail", "smailr", "icloud", "icloud_url", "gmail", "chongzhi"}:
+    if provider in {"cfworker", "remail", "mailnest", "smailr", "icloud", "icloud_url", "gmail", "chongzhi"}:
         return False
     return True  # Catch-all for plain Graph/IMAP mailboxes
 

--- a/tests/test_email_otp_filtering.py
+++ b/tests/test_email_otp_filtering.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 from sms_tool import codex_oauth
 from sms_tool import mailbox as mailbox_module
 from sms_tool.mailbox import (

--- a/tests/test_mailnest_mailbox.py
+++ b/tests/test_mailnest_mailbox.py
@@ -1,0 +1,132 @@
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+from sms_tool import mailbox_mailnest, mailbox_parsers
+from sms_tool.mailbox_types import MailboxAccount
+
+
+class FakeResponse:
+    def __init__(self, body, status_code=200, text=""):
+        self._body = body
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._body
+
+
+def _cfg():
+    return {
+        "mailnest": {
+            "enabled": True,
+            "base_url": "https://mailnest.example",
+            "api_key": "mn-secret",
+            "project_code": "chatgpt001",
+            "mode": "temporary",
+            "timeout": 17,
+        },
+        "otp_poll_interval": 1,
+    }
+
+
+class MailNestParserTests(unittest.TestCase):
+    def test_mailnest_graph_token_line_is_explicit_graph_provider(self):
+        account = mailbox_parsers.parse_mailbox_pool_line(
+            "mailnest://user@outlook.com----login-pass----9e5f94bc-e8a4-4e73-b8be-63364c29d753----rt-secret",
+            "mailboxes.txt",
+            1,
+        )
+
+        self.assertEqual(account.provider, "mailnest_graph")
+        self.assertEqual(account.email, "user@outlook.com")
+        self.assertEqual(account.password, "login-pass")
+        self.assertEqual(account.token, "9e5f94bc-e8a4-4e73-b8be-63364c29d753")
+        self.assertEqual(account.refresh_token, "rt-secret")
+        self.assertEqual(account.auth_mode, "oauth_refresh")
+
+    def test_mailnest_api_line_keeps_receive_mode(self):
+        account = mailbox_parsers.parse_mailbox_pool_line(
+            "mailnest://user@outlook.com---user_mailbox---order-1",
+            "mailboxes.txt",
+            2,
+        )
+
+        self.assertEqual(account.provider, "mailnest")
+        self.assertEqual(account.email, "user@outlook.com")
+        self.assertEqual(account.auth_mode, "user_mailbox")
+        self.assertEqual(account.token, "order-1")
+
+    def test_mailbox_file_loader_accepts_mailnest_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "mailboxes.txt"
+            path.write_text("mailnest://user@outlook.com---temporary---order-1\n", encoding="utf-8")
+
+            accounts = mailbox_parsers._parse_mailbox_token_file(path)
+
+        self.assertEqual(len(accounts), 1)
+        self.assertEqual(accounts[0].provider, "mailnest")
+
+
+class MailNestApiTests(unittest.TestCase):
+    def test_temporary_purchase_uses_project_code_and_bearer_auth(self):
+        response = FakeResponse({
+            "code": "00000",
+            "data": [{
+                "id": "order-1",
+                "email": "user@outlook.com",
+                "project_code": "chatgpt001",
+                "project_name": "ChatGPT",
+                "price": "0.010",
+            }],
+        })
+        args = Namespace(count=1, mailnest_mode="temporary", mailnest_project_code=None)
+        with patch.object(mailbox_mailnest, "_email_cfg", return_value=_cfg()), \
+             patch.object(mailbox_mailnest.curl_requests, "post", return_value=response) as post:
+            accounts = mailbox_mailnest._create_mailnest_mailboxes(args)
+
+        self.assertEqual(accounts[0].provider, "mailnest")
+        self.assertEqual(accounts[0].auth_mode, "temporary")
+        self.assertEqual(accounts[0].email, "user@outlook.com")
+        kwargs = post.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer mn-secret")
+        self.assertEqual(kwargs["json"], {"count": 1, "project_code": "chatgpt001"})
+        self.assertTrue(post.call_args.args[0].endswith("/api/v1/email/temporary/buy"))
+
+    def test_user_mailbox_receive_normalizes_mailnest_message_to_graph_shape(self):
+        response = FakeResponse({
+            "code": "00000",
+            "data": [{
+                "id": "msg-1",
+                "email": "user@outlook.com",
+                "subject": "Your verification code",
+                "from_email": "noreply@tm.openai.com",
+                "to_email": "user@outlook.com",
+                "body_preview": "Use this code.",
+                "body": "<p>Use this code.</p>",
+                "code_match": "123456",
+                "received_at": "2026-06-24T10:14:51.992Z",
+            }],
+        })
+        mailbox = MailboxAccount("user@outlook.com", provider="mailnest", auth_mode="user_mailbox")
+        with patch.object(mailbox_mailnest.curl_requests, "post", return_value=response):
+            messages = mailbox_mailnest._fetch_mailnest_messages(mailbox, email_cfg=_cfg())
+
+        self.assertEqual(messages[0]["id"], "msg-1")
+        self.assertEqual(messages[0]["from"]["emailAddress"]["address"], "noreply@tm.openai.com")
+        self.assertIn("123456", messages[0]["bodyPreview"])
+        self.assertEqual(messages[0]["toRecipients"][0]["emailAddress"]["address"], "user@outlook.com")
+
+    def test_transient_receive_code_returns_empty_messages(self):
+        response = FakeResponse({"code": "D0005", "msg": "try later", "data": None})
+        mailbox = MailboxAccount("user@outlook.com", provider="mailnest", auth_mode="temporary")
+        with patch.object(mailbox_mailnest.curl_requests, "post", return_value=response):
+            messages = mailbox_mailnest._fetch_mailnest_messages(mailbox, email_cfg=_cfg())
+
+        self.assertEqual(messages, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
新增outlook邮箱提供商，可以通过配置`api key`和直接导入购买的`Graph`令牌号两种方式使用

配置`api key`测试截图如下：
<img width="556" height="896" alt="image" src="https://github.com/user-attachments/assets/cd82357b-4315-4ff8-b7e7-e024908095d1" />

使用购买的`Graph`令牌号
<img width="542" height="848" alt="image" src="https://github.com/user-attachments/assets/b9667f68-5cc2-41c0-89d3-178e42e2aae1" />
